### PR TITLE
remove pyspm.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 dependencies = [
     "findiff",
     "pynxtools>=0.9.2",
-    "pySPM==0.6.2",  # SPM file reader for Bruker files
+    # "pySPM==0.6.2",  # SPM file reader for Bruker files use it when you have Bruker files
     "pint"
 ]
 


### PR DESCRIPTION
It is needed because it creates version conflicts in Nomad.