### PR TITLE
Add DOI from Zenodo

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,44 +10,44 @@ version: 0.2.1
 authors:
   - given-names: Rubel
     family-names: Mozumder
-    orcid: '0009-0007-5926-6646'
+    orcid: 'https://orcid.org/0009-0007-5926-6646'
   - given-names: Lukas
     family-names: Pielsticker
-    orcid: '0000-0001-9361-8333'
+    orcid: 'https://orcid.org/0000-0001-9361-8333'
   - given-names: Yichen
     family-names: Jin
-    orcid: '0000-0001-9546-1202'
+    orcid: 'https://orcid.org/0000-0001-9546-1202'
   - given-names: Florian
     family-names: Dobener
-    orcid: '0000-0003-1987-6224'
+    orcid: 'https://orcid.org/0000-0003-1987-6224'
   - given-names: Lev
     family-names: Ginzburg
-    orcid: '0000-0001-8929-1040'
+    orcid: 'https://orcid.org/0000-0001-8929-1040'
   - given-names: Markus
     family-names: Kühbach
-    orcid: '0000-0002-7117-5196'
+    orcid: 'https://orcid.org/0000-0002-7117-5196'
   - given-names: Sherjeel
     family-names: Shabih
-    orcid: '0009-0008-6635-4465'
+    orcid: 'https://orcid.org/0009-0008-6635-4465'
   - given-names: Tamás
     family-names: Haraszti
-    orcid: '0000-0002-7095-4358'
+    orcid: 'https://orcid.org/0000-0002-7095-4358'
   - given-names: Carlos-Andres
     family-names: Palma
-    orcid: '0000-0001-5576-8496'
+    orcid: 'https://orcid.org/0000-0001-5576-8496'
   - given-names: Sandor
     family-names: Brockhauser
-    orcid: '0000-0002-9700-4803'
+    orcid: 'https://orcid.org/0000-0002-9700-4803'
   - given-names: Christoph T.
     family-names: Koch
-    orcid: '0000-0002-3984-1523'
+    orcid: 'https://orcid.org/0000-0002-3984-1523'
   - given-names: Heiko B.
     family-names: Weber
-    orcid: '0000-0002-6403-9022'
+    orcid: 'https://orcid.org/0000-0002-6403-9022'
   - given-names: Claudia
     family-names: Draxl
-    orcid: '0000-0003-3523-6657'
-doi: ''
+    orcid: 'https://orcid.org/0000-0003-3523-6657'
+doi: 'https://doi.org/10.5281/zenodo.17390485'
 repository-code: 'https://github.com/FAIRmat-NFDI/pynxtools-spm'
 url: 'https://fairmat-nfdi.github.io/pynxtools-spm/'
 abstract:


### PR DESCRIPTION
- [x] Add Zenodo DOI and keep Orcid ID with `https://orcid.org` prefix.